### PR TITLE
restart notification and error posting

### DIFF
--- a/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
+++ b/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
@@ -65,6 +65,8 @@ public final class ComputeModule {
      * Starts the client polling loop. This is blocking, run in the background needed.
      */
     public Void start() {
+        // notify the runtime of (re)start of the module
+        client.postRestart();
         while (true) {
             client.getJob().ifPresent(job -> {
                 ListenableFuture<Result> future = executor.submit(() -> execute(job));

--- a/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
+++ b/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
@@ -56,6 +56,7 @@ public final class ComputeModule {
     private final Map<String, FunctionRunner<?, ?>> functions;
     private final Client client;
     private final ListeningExecutorService executor;
+    private final boolean reportsRestart;
 
     public static ComputeModuleBuilder builder() {
         return new ComputeModuleBuilder();
@@ -66,7 +67,9 @@ public final class ComputeModule {
      */
     public Void start() {
         // notify the runtime of (re)start of the module
-        client.postRestart();
+        if (reportsRestart) {
+            client.postRestart();
+        }
         while (true) {
             client.getJob().ifPresent(job -> {
                 ListenableFuture<Result> future = executor.submit(() -> execute(job));
@@ -122,10 +125,11 @@ public final class ComputeModule {
     }
 
     private ComputeModule(
-            Client client, ListeningExecutorService executor, Map<String, FunctionRunner<?, ?>> functions) {
+            Client client, ListeningExecutorService executor, Map<String, FunctionRunner<?, ?>> functions, boolean reportsRestart) {
         this.client = client;
         this.executor = executor;
         this.functions = functions;
+        this.reportsRestart = reportsRestart;
     }
 
     public static final class ComputeModuleBuilder {
@@ -134,6 +138,7 @@ public final class ComputeModule {
                 Optional.empty(); // ComputeModuleClient construction is deferred due to env vars
         private ListeningExecutorService executor =
                 MoreExecutors.listeningDecorator(Executors.newVirtualThreadPerTaskExecutor());
+        private boolean reportsRestart = false;
 
         private ComputeModuleBuilder() {
             functions = new HashMap<>();
@@ -177,8 +182,13 @@ public final class ComputeModule {
             return this;
         }
 
+        public ComputeModuleBuilder withReportsRestart() {
+            this.reportsRestart = true;
+            return this;
+        }
+
         public ComputeModule build() {
-            return new ComputeModule(client.orElseGet(() -> new ComputeModuleClient()), executor, functions);
+            return new ComputeModule(client.orElseGet(() -> new ComputeModuleClient()), executor, functions, reportsRestart);
         }
     }
 }

--- a/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
+++ b/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
@@ -125,7 +125,10 @@ public final class ComputeModule {
     }
 
     private ComputeModule(
-            Client client, ListeningExecutorService executor, Map<String, FunctionRunner<?, ?>> functions, boolean reportsRestart) {
+            Client client,
+            ListeningExecutorService executor,
+            Map<String, FunctionRunner<?, ?>> functions,
+            boolean reportsRestart) {
         this.client = client;
         this.executor = executor;
         this.functions = functions;
@@ -188,7 +191,8 @@ public final class ComputeModule {
         }
 
         public ComputeModule build() {
-            return new ComputeModule(client.orElseGet(() -> new ComputeModuleClient()), executor, functions, reportsRestart);
+            return new ComputeModule(
+                    client.orElseGet(() -> new ComputeModuleClient()), executor, functions, reportsRestart);
         }
     }
 }

--- a/lib/src/main/java/com/palantir/computemodules/client/Client.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/Client.java
@@ -23,4 +23,6 @@ public interface Client {
     Optional<ComputeModuleJob> getJob();
 
     void postResult(String jobId, InputStream result);
+
+    void postRestart();
 }

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -93,8 +93,7 @@ public final class ComputeModuleClient implements Client {
                 Thread.sleep(1000);
             }
         } catch (Exception e) {
-            error = new String(
-                    "Failed to post error for jobId: " + jobId + "error: " + e.toString());
+            error = new String("Failed to post error for jobId: " + jobId + "error: " + e.toString());
             log.error("Failed to post result", SafeArg.of("jobId", jobId), e);
         }
         log.error(

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -79,7 +79,7 @@ public final class ComputeModuleClient implements Client {
                 .uri(URI.create("http://127.0.0.1:8946/results" + "/" + jobId))
                 .POST(BodyPublishers.ofInputStream(() -> result))
                 .build();
-        String error;
+        String error = "";
         try {
             for (Integer i = 0; i < POST_RESULT_MAX_ATTEMPTS; i++) {
                 HttpResponse response = client.send(request, BodyHandlers.ofString());
@@ -88,14 +88,13 @@ public final class ComputeModuleClient implements Client {
                     return;
                 }
                 error = new String(
-                        "Failed to post error for jobId: " + jobId + ", statusCode: " + response.statusCode(),
-                        StandardCharsets.UTF_8);
+                        "Failed to post error for jobId: " + jobId + ", statusCode: " + response.statusCode());
                 log.error("Failed to post error", SafeArg.of("jobId", error));
                 Thread.sleep(1000);
             }
         } catch (Exception e) {
             error = new String(
-                    "Failed to post error for jobId: " + jobId + "error: " + e.toString(), StandardCharsets.UTF_8);
+                    "Failed to post error for jobId: " + jobId + "error: " + e.toString());
             log.error("Failed to post result", SafeArg.of("jobId", jobId), e);
         }
         log.error(
@@ -127,6 +126,7 @@ public final class ComputeModuleClient implements Client {
         }
     }
 
+    @Override
     public void postRestart() {
         HttpRequest request = postRequest
                 .copy()

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -87,15 +87,22 @@ public final class ComputeModuleClient implements Client {
                     log.info("Successfully posted result", SafeArg.of("jobId", jobId));
                     return;
                 }
-                error = new String("Failed to post error for jobId: " + jobId + ", statusCode: " + response.statusCode(), StandardCharsets.UTF_8);
+                error = new String(
+                        "Failed to post error for jobId: " + jobId + ", statusCode: " + response.statusCode(),
+                        StandardCharsets.UTF_8);
                 log.error("Failed to post error", SafeArg.of("jobId", error));
                 Thread.sleep(1000);
             }
         } catch (Exception e) {
-            error = new String("Failed to post error for jobId: " + jobId + "error: " + e.toString(), StandardCharsets.UTF_8);
+            error = new String(
+                    "Failed to post error for jobId: " + jobId + "error: " + e.toString(), StandardCharsets.UTF_8);
             log.error("Failed to post result", SafeArg.of("jobId", jobId), e);
         }
-        log.error("Failed to post result after several attempts. Now attempting to return the error as the result. ", SafeArg.of("jobId", jobId), SafeArg.of("error", error),  SafeArg.of("attempts", POST_RESULT_MAX_ATTEMPTS));
+        log.error(
+                "Failed to post result after several attempts. Now attempting to return the error as the result. ",
+                SafeArg.of("jobId", jobId),
+                SafeArg.of("error", error),
+                SafeArg.of("attempts", POST_RESULT_MAX_ATTEMPTS));
         postError(jobId, error);
     }
 

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -82,7 +82,7 @@ public final class ComputeModuleClient implements Client {
         String error = "";
         try {
             for (Integer i = 0; i < POST_RESULT_MAX_ATTEMPTS; i++) {
-                HttpResponse response = client.send(request, BodyHandlers.ofString());
+                HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
                 if (response.statusCode() == 204) {
                     log.info("Successfully posted result", SafeArg.of("jobId", jobId));
                     return;
@@ -113,7 +113,7 @@ public final class ComputeModuleClient implements Client {
                 .build();
         for (Integer i = 0; i < POST_ERROR_MAX_ATTEMPTS; i++) {
             try {
-                HttpResponse response = client.send(request, BodyHandlers.ofString());
+                HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
                 if (response.statusCode() == 204) {
                     log.info("Successfully posted error", SafeArg.of("jobId", jobId));
                     return;

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 
 public final class ComputeModuleClient implements Client {
     private static final SafeLogger log = SafeLoggerFactory.get(ComputeModuleClient.class);
+    private static final Integer POST_RESULT_MAX_ATTEMPTS = 5;
+    private static final Integer POST_ERROR_MAX_ATTEMPTS = 3;
 
     private final HttpClient client;
     private final HttpRequest getRequest;
@@ -77,10 +79,57 @@ public final class ComputeModuleClient implements Client {
                 .uri(URI.create("http://127.0.0.1:8946/results" + "/" + jobId))
                 .POST(BodyPublishers.ofInputStream(() -> result))
                 .build();
+        String error;
+        try {
+            for (Integer i = 0; i < POST_RESULT_MAX_ATTEMPTS; i++) {
+                HttpResponse response = client.send(request, BodyHandlers.ofString());
+                if (response.statusCode() == 204) {
+                    log.info("Successfully posted result", SafeArg.of("jobId", jobId));
+                    return;
+                }
+                error = new String("Failed to post error for jobId: " + jobId + ", statusCode: " + response.statusCode(), StandardCharsets.UTF_8);
+                log.error("Failed to post error", SafeArg.of("jobId", error));
+                Thread.sleep(1000);
+            }
+        } catch (Exception e) {
+            error = new String("Failed to post error for jobId: " + jobId + "error: " + e.toString(), StandardCharsets.UTF_8);
+            log.error("Failed to post result", SafeArg.of("jobId", jobId), e);
+        }
+        log.error("Failed to post result after several attempts. Now attempting to return the error as the result. ", SafeArg.of("jobId", jobId), SafeArg.of("error", error),  SafeArg.of("attempts", POST_RESULT_MAX_ATTEMPTS));
+        postError(jobId, error);
+    }
+
+    private void postError(String jobId, String errorString) {
+        HttpRequest request = postRequest
+                .copy()
+                .uri(URI.create("http://127.0.0.1:8946/results" + "/" + jobId))
+                .POST(BodyPublishers.ofString(errorString))
+                .build();
+        for (Integer i = 0; i < POST_ERROR_MAX_ATTEMPTS; i++) {
+            try {
+                HttpResponse response = client.send(request, BodyHandlers.ofString());
+                if (response.statusCode() == 204) {
+                    log.info("Successfully posted error", SafeArg.of("jobId", jobId));
+                    return;
+                }
+                log.error("Failed to post error", SafeArg.of("jobId", jobId), SafeArg.of("response", response));
+                Thread.sleep(1000);
+            } catch (Exception e) {
+                log.error("Failed to post error", SafeArg.of("jobId", jobId), e);
+            }
+        }
+    }
+
+    public void postRestart() {
+        HttpRequest request = postRequest
+                .copy()
+                .uri(URI.create("http://127.0.0.1:8946/restart-notify"))
+                .POST(BodyPublishers.ofString(""))
+                .build();
         try {
             client.send(request, BodyHandlers.ofString());
         } catch (Exception e) {
-            log.error("Failed to post result", SafeArg.of("jobId", jobId), e);
+            log.error("Failed to post restart", e);
         }
     }
 }

--- a/lib/src/main/java/com/palantir/computemodules/client/TestClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/TestClient.java
@@ -109,4 +109,7 @@ public final class TestClient implements Client {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void postRestart() {}
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
1. If posting the job result fails 5 times an exception gets raised but the forwarder doesn't know about it, since it never gets the message from the user code container.
2. If the user code crashes the forwarder will think the user code is still running until the user code posts a result for the same jobId. However, after restarting the user code will not know about the previously failed job so it will never report on it. This way a node/module might be blocked from receiving new requests after restarting:

https://github.palantir.build/foundry/interactive-infra/issues/9237
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
1. If the job posting fails 5 times (e.g. result too large) then the client tries 5 more times to post just a simple error message.
2. We inform the forwarder whenever a node starts up so it will remove all existing jobs related to it that it thinks are still running.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
