### PR TITLE
Add function schema inference + postSchemas

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
     }
 }
 
+apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.failure-reports'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.baseline-error-prone-root'
@@ -45,7 +46,6 @@ allprojects {
     apply plugin: 'com.palantir.java-format'
     apply plugin: 'com.palantir.baseline-class-uniqueness'
     apply plugin: 'com.palantir.baseline-null-away'
-    apply plugin: 'com.palantir.external-publish-jar'
     apply plugin: 'com.palantir.jakarta-package-alignment'
 
     version rootProject.version

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.28.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.18.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.33.0'
+        classpath 'com.palantir.gradle.conjure:gradle-conjure:5.64.0'
         constraints {
             classpath('org.apache.logging.log4j:log4j-core:2.17.1'){ because 'Avoid vulnerable versions of log4j' }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ buildscript {
     }
 }
 
-apply plugin: 'com.palantir.external-publish'
 apply plugin: 'com.palantir.failure-reports'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.baseline-error-prone-root'
@@ -46,6 +45,7 @@ allprojects {
     apply plugin: 'com.palantir.java-format'
     apply plugin: 'com.palantir.baseline-class-uniqueness'
     apply plugin: 'com.palantir.baseline-null-away'
+    apply plugin: 'com.palantir.external-publish-jar'
     apply plugin: 'com.palantir.jakarta-package-alignment'
 
     version rootProject.version

--- a/lib-api/build.gradle
+++ b/lib-api/build.gradle
@@ -1,0 +1,17 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'com.palantir.conjure'

--- a/lib-api/build.gradle
+++ b/lib-api/build.gradle
@@ -15,3 +15,4 @@
  */
 
 apply plugin: 'com.palantir.conjure'
+apply plugin: 'com.palantir.external-publish-conjure'

--- a/lib-api/build.gradle
+++ b/lib-api/build.gradle
@@ -15,4 +15,3 @@
  */
 
 apply plugin: 'com.palantir.conjure'
-apply plugin: 'com.palantir.external-publish-conjure'

--- a/lib-api/src/main/conjure/lib-api.yml
+++ b/lib-api/src/main/conjure/lib-api.yml
@@ -4,7 +4,7 @@ types:
       external:
         java: java.math.BigDecimal
   definitions:
-    default-package: com.palantir.computemodules.functions
+    default-package: com.palantir.computemodules.functions.api
     objects:
       DataType:
         docs: |
@@ -101,6 +101,8 @@ types:
             type: optional<map<CustomTypeFieldName, CustomTypeFieldMetadata>>
             docs: |
               When this map is present, it is expected that metadata is provided for every field.
+      UnknownType:
+        fields: {}
 
 
       CustomTypeFieldName:

--- a/lib-api/src/main/conjure/lib-api.yml
+++ b/lib-api/src/main/conjure/lib-api.yml
@@ -1,0 +1,294 @@
+types:
+  imports:
+    BigDecimal:
+      external:
+        java: java.math.BigDecimal
+  definitions:
+    default-package: com.palantir.computemodules.functions
+    objects:
+      DataType:
+        docs: |
+          All types supported by the Function Registry.
+        union:
+          boolean: BooleanType
+          integer: IntegerType
+          long: LongType
+          float: FloatType
+          double: DoubleType
+          decimal: DecimalType
+          string: StringType
+          date: DateType
+          timestamp: TimestampType
+          list: ListType
+          set: SetType
+          map: MapType
+          optionalType: OptionalType
+          anonymousCustomType: AnonymousCustomType
+          byte: ByteType
+          short: ShortType
+      BooleanType:
+        fields: {}
+      IntegerType:
+        fields: {}
+      LongType:
+        fields: {}
+      FloatType:
+        fields: {}
+      DoubleType:
+        fields: {}
+      DecimalType:
+        docs: |
+          A function registered with a Decimal type input or output must provide guarantees that it can correctly handle
+          any decimal value within the valid range as specified by the field's scale and precision.
+          
+          For example, a function registered with a Decimal input of precision 5 and scale 3 should be able to correctly
+          handle any decimal value between 0.000 and 99.999, inclusive. 
+          
+          Note that numbers such as 3 and 4.1 are inside of this valid range even though their values are not written
+          with precision 5 and scale 3.
+        fields:
+          precision:
+            docs: |
+              If present, a decimal field's precision is the maximum number of digits in the number, excluding leading 
+              zeros to the left of the decimal point and trailing zeros to the right of the decimal point.
+              
+              If unspecified, the decimal field has unbounded precision.
+              
+              For example, the value 10.45 has precision 4 even though it could be represented as 010.450.
+              Provided the field's scale is large enough (see docs below), the value 10.45 is valid for a decimal field
+              with precision 4 or greater.
+            type: optional<integer>
+            safety: safe
+          scale:
+            docs: |
+              If present, a decimal field's scale is the maximum number of digits to the right of the decimal point, 
+              excluding trailing zeros. 
+              
+              If unspecified, the decimal field has unbounded scale.
+
+              For example, the value 10.45 has scale 2 even though it could be represented as 10.450.
+              Provided the field's precision is large enough (see docs above), the value 10.45 is valid for a decimal
+              field with precision 2 or greater.
+            type: optional<integer>
+            safety: safe
+      StringType:
+        fields: {}
+      DateType:
+        fields: {}
+      TimestampType:
+        fields: {}
+      ByteType:
+        fields: {}
+      ShortType:
+        fields: {}
+      ListType:
+        fields:
+          elementsType: DataType
+      SetType:
+        fields:
+          elementsType: DataType
+      MapType:
+        fields:
+          keysType: DataType
+          valuesType: DataType
+      OptionalType:
+        fields:
+          wrappedType: DataType
+      AnonymousCustomType:
+        fields:
+          fields: map<CustomTypeFieldName, DataType>
+          fieldMetadata:
+            type: optional<map<CustomTypeFieldName, CustomTypeFieldMetadata>>
+            docs: |
+              When this map is present, it is expected that metadata is provided for every field.
+
+
+      CustomTypeFieldName:
+        alias: string
+        safety: unsafe
+      CustomTypeFieldMetadata:
+        fields:
+          required:
+            type: boolean
+            safety: safe
+          documentation: optional<Documentation>
+      Documentation:
+        alias: string
+        safety: unsafe
+
+      InputName:
+        alias: string
+        safety: unsafe
+      ObjectTypeId:
+        alias: string
+        safety: unsafe
+      PropertyId:
+        alias: string
+        safety: unsafe
+      ObjectPrimaryKey:
+        alias: map<PropertyId, any>
+      Constraint:
+        union:
+          integer: IntegerRangeConstraint
+          long: LongRangeConstraint
+          float: FloatRangeConstraint
+          double: DoubleRangeConstraint
+          decimal: DecimalRangeConstraint
+          date: DateRangeConstraint
+          timestamp: TimeStampRangeConstraint
+
+      IntegerRangeConstraint:
+        fields:
+          min:
+            type: optional<integer>
+            safety: unsafe
+          max:
+            type: optional<integer>
+            safety: unsafe
+
+      LongRangeConstraint:
+        fields:
+          min:
+            type: optional<safelong>
+            safety: unsafe
+          max:
+            type: optional<safelong>
+            safety: unsafe
+
+      FloatRangeConstraint:
+        fields:
+          min:
+            type: optional<double>
+            safety: unsafe
+          max:
+            type: optional<double>
+            safety: unsafe
+
+      DoubleRangeConstraint:
+        fields:
+          min:
+            type: optional<double>
+            safety: unsafe
+          max:
+            type: optional<double>
+            safety: unsafe
+
+      DecimalRangeConstraint:
+        fields:
+          min: optional<BigDecimal>
+          max: optional<BigDecimal>
+
+      DateRangeConstraint:
+        fields:
+          min:
+            docs: If present, this should be an ISO 8601 date.
+            type: optional<string>
+            safety: unsafe
+          max:
+            docs: If present, this should be an ISO 8601 date.
+            type: optional<string>
+            safety: unsafe
+
+      TimeStampRangeConstraint:
+        fields:
+          min:
+            type: optional<datetime>
+            safety: unsafe
+          max:
+            type: optional<datetime>
+            safety: unsafe
+
+      # Values
+      Value:
+        union:
+          boolean: BooleanValue
+          integer: IntegerValue
+          long: LongValue
+          float: FloatValue
+          double: DoubleValue
+          string: StringValue
+          date: DateValue
+          timestamp: TimestampValue
+          list: ListValue
+          set: SetValue
+          objectLocator: ObjectLocatorValue
+          null: NullValue
+
+      BooleanValue:
+        alias: boolean
+        safety: unsafe
+      IntegerValue:
+        alias: integer
+        safety: unsafe
+      LongValue:
+        alias: safelong
+        safety: unsafe
+      FloatValue:
+        alias: double
+        safety: unsafe
+      DoubleValue:
+        alias: double
+        safety: unsafe
+      StringValue:
+        alias: string
+        safety: unsafe
+      DateValue:
+        alias: string
+        safety: unsafe
+      TimestampValue:
+        alias: datetime
+        safety: unsafe
+      ListValue:
+        fields:
+          values: list<Value>
+      SetValue:
+        fields:
+          values: set<Value>
+      ObjectLocatorValue:
+        fields:
+          typeId: ObjectTypeId
+          primaryKey: ObjectPrimaryKey
+      NullValue:
+        fields: {}
+
+      FunctionInputType:
+        fields:
+          name: InputName
+          description:
+            type: optional<string>
+            safety: unsafe
+          dataType: DataType
+          required:
+            type: boolean
+            safety: safe
+          defaultValue: optional<Value>
+          constraints: list<Constraint>
+
+      FunctionOutputType:
+        union:
+          single: SingleOutputType
+          void: VoidOutputType
+
+      SingleOutputType:
+        fields:
+          description:
+            type: optional<string>
+            safety: unsafe
+          dataType: DataType
+
+      VoidOutputType:
+        docs: Indicates no output value is returned from the defined function.
+        fields: { }
+
+      QueryRunnerSchemaParseIssue:
+        values:
+          - CANNOT_PARSE_INPUTS
+          - CANNOT_PARSE_OUTPUT
+      QueryRunnerSchema:
+        fields:
+          functionName:
+            safety: unsafe
+            type: string
+          inputs: list<FunctionInputType>
+          output: FunctionOutputType
+          issues: list<QueryRunnerSchemaParseIssue>

--- a/lib-api/src/main/conjure/lib-api.yml
+++ b/lib-api/src/main/conjure/lib-api.yml
@@ -282,15 +282,15 @@ types:
         docs: Indicates no output value is returned from the defined function.
         fields: { }
 
-      QueryRunnerSchemaParseIssue:
+      FunctionRunnerSchemaParseIssue:
         values:
           - CANNOT_PARSE_INPUTS
           - CANNOT_PARSE_OUTPUT
-      QueryRunnerSchema:
+      FunctionRunnerSchema:
         fields:
           functionName:
             safety: unsafe
             type: string
           inputs: list<FunctionInputType>
           output: FunctionOutputType
-          issues: list<QueryRunnerSchemaParseIssue>
+          issues: list<FunctionRunnerSchemaParseIssue>

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'com.palantir.external-publish-jar'
+
 dependencies {
     implementation 'com.google.guava:guava'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.4'
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation project(':lib-api:lib-api-objects')
 
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,7 +5,10 @@ dependencies {
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation project(':lib-api:lib-api-objects')
+    implementation 'one.util:streamex'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'com.palantir.external-publish-jar'
-
 dependencies {
     implementation 'com.google.guava:guava'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation 'com.google.guava:guava'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.4'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.0'
     implementation 'com.palantir.safe-logging:logger'
     implementation 'com.palantir.safe-logging:preconditions'
     implementation project(':lib-api:lib-api-objects')

--- a/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
+++ b/lib/src/main/java/com/palantir/computemodules/ComputeModule.java
@@ -29,6 +29,7 @@ import com.palantir.computemodules.functions.FunctionRunner;
 import com.palantir.computemodules.functions.results.Failed;
 import com.palantir.computemodules.functions.results.Ok;
 import com.palantir.computemodules.functions.results.Result;
+import com.palantir.computemodules.functions.schema.FunctionRunnerSchemaConverter;
 import com.palantir.computemodules.functions.serde.DefaultDeserializer;
 import com.palantir.computemodules.functions.serde.DefaultSerializer;
 import com.palantir.logsafe.SafeArg;
@@ -68,6 +69,7 @@ public final class ComputeModule {
      * Starts the client polling loop. This is blocking, run in the background needed.
      */
     public Void start() {
+        client.postSchemas(FunctionRunnerSchemaConverter.getFunctionSchemas(functions));
         while (true) {
             client.getJob().ifPresent(job -> {
                 ListenableFuture<Result> future = executor.submit(() -> execute(job));

--- a/lib/src/main/java/com/palantir/computemodules/auth/PipelinesAuth.java
+++ b/lib/src/main/java/com/palantir/computemodules/auth/PipelinesAuth.java
@@ -29,6 +29,7 @@ public final class PipelinesAuth {
     // Produces a bearer token that can be used to make calls to access pipeline resources.
     // This is only available in pipeline mode.
     public static String retrievePipelineToken() {
+        // TODO(.): Replace with EnvVars.Reserved
         String tokenFilePath = System.getenv("BUILD2_TOKEN");
         if (tokenFilePath == null || tokenFilePath.isEmpty()) {
             throw new SafeRuntimeException(

--- a/lib/src/main/java/com/palantir/computemodules/auth/ThirdPartyAuth.java
+++ b/lib/src/main/java/com/palantir/computemodules/auth/ThirdPartyAuth.java
@@ -17,6 +17,7 @@ package com.palantir.computemodules.auth;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.computemodules.client.config.EnvVars;
 import com.palantir.computemodules.ssl.SslUtils;
 import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import com.palantir.logsafe.exceptions.SafeUncheckedIoException;
@@ -41,8 +42,8 @@ public final class ThirdPartyAuth {
     private ThirdPartyAuth() {}
 
     public static ThirdPartyCredentials retrieveThirdPartyIdAndCreds() {
-        String clientId = System.getenv("CLIENT_ID");
-        String clientSecret = System.getenv("CLIENT_SECRET");
+        String clientId = EnvVars.Reserved.CLIENT_ID.get();
+        String clientSecret = EnvVars.Reserved.CLIENT_SECRET.get();
         if (clientId.isEmpty() || clientSecret.isEmpty()) {
             throw new SafeRuntimeException(
                     "One or both of required environment variables not found: CLIENT_ID, CLIENT_SECRET. "
@@ -62,7 +63,7 @@ public final class ThirdPartyAuth {
 
             String url = HTTPS + hostname + OAUTH_TOKEN_ENDPOINT;
 
-            SSLContext sslContext = SslUtils.createSslContext(System.getenv("DEFAULT_CA_PATH"));
+            SSLContext sslContext = SslUtils.createSslContext(EnvVars.Reserved.DEFAULT_CA_PATH.get());
 
             HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
             HttpRequest request = HttpRequest.newBuilder()

--- a/lib/src/main/java/com/palantir/computemodules/client/Client.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/Client.java
@@ -15,7 +15,9 @@
  */
 package com.palantir.computemodules.client;
 
+import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 
 public interface Client {
@@ -23,4 +25,6 @@ public interface Client {
     Optional<ComputeModuleJob> getJob();
 
     void postResult(String jobId, InputStream result);
+
+    void postSchemas(List<FunctionRunnerSchema> functionSchemas);
 }

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -16,6 +16,7 @@
 package com.palantir.computemodules.client;
 
 import com.palantir.computemodules.client.config.EnvVars;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
@@ -27,6 +28,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
 import java.util.Optional;
 
 public final class ComputeModuleClient implements Client {
@@ -83,4 +85,7 @@ public final class ComputeModuleClient implements Client {
             log.error("Failed to post result", SafeArg.of("jobId", jobId), e);
         }
     }
+
+    @Override
+    public void postSchemas(List<FunctionRunnerSchema> functionSchemas) {}
 }

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -17,6 +17,7 @@ package com.palantir.computemodules.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.palantir.computemodules.client.config.EnvVars;
 import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
 import com.palantir.logsafe.SafeArg;
@@ -38,8 +39,9 @@ import java.util.Optional;
 public final class ComputeModuleClient implements Client {
     private static final SafeLogger log = SafeLoggerFactory.get(ComputeModuleClient.class);
     private static final int POST_SCHEMAS_MAX_ATTEMPTS = 5;
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module());
 
+    private final String runtimeHost;
     private final HttpClient client;
     private final HttpRequest getRequest;
     private final HttpRequest.Builder postRequest;
@@ -48,15 +50,16 @@ public final class ComputeModuleClient implements Client {
 
     public ComputeModuleClient() {
         String moduleAuthToken = EnvVars.Reserved.MODULE_AUTH_TOKEN.get();
+        this.runtimeHost = EnvVars.Reserved.RUNTIME_HOST.get();
         this.getRequest = HttpRequest.newBuilder()
-                .uri(URI.create("http://127.0.0.1:8946/job"))
+                .uri(URI.create(String.format("http://%s:8946/job", runtimeHost)))
                 .header("Module-Auth-Token", moduleAuthToken)
                 .build();
         this.postRequest = HttpRequest.newBuilder()
                 .header("Module-Auth-Token", moduleAuthToken)
                 .header("Content-Type", "application/octet-stream");
         this.postSchemasRequest = HttpRequest.newBuilder()
-                .uri(URI.create("http://127.0.0.1:8946/schemas"))
+                .uri(URI.create(String.format("http://%s:8946/schemas", runtimeHost)))
                 .header("Content-Type", "application/json");
         this.client = HttpClient.newBuilder().build();
     }
@@ -86,7 +89,7 @@ public final class ComputeModuleClient implements Client {
     public void postResult(String jobId, InputStream result) {
         HttpRequest request = postRequest
                 .copy()
-                .uri(URI.create("http://127.0.0.1:8946/results" + "/" + jobId))
+                .uri(URI.create(String.format("http://%s:8946/results/%s", runtimeHost, jobId)))
                 .POST(BodyPublishers.ofInputStream(() -> result))
                 .build();
         try {

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -15,13 +15,17 @@
  */
 package com.palantir.computemodules.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.computemodules.client.config.EnvVars;
 import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
 import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.UnsafeArg;
 import com.palantir.logsafe.logger.SafeLogger;
 import com.palantir.logsafe.logger.SafeLoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -33,10 +37,13 @@ import java.util.Optional;
 
 public final class ComputeModuleClient implements Client {
     private static final SafeLogger log = SafeLoggerFactory.get(ComputeModuleClient.class);
+    private static final int POST_SCHEMAS_MAX_ATTEMPTS = 5;
+    private static final ObjectMapper mapper = new ObjectMapper();
 
     private final HttpClient client;
     private final HttpRequest getRequest;
     private final HttpRequest.Builder postRequest;
+    private final HttpRequest.Builder postSchemasRequest;
     private final TaggedJobDeserializer deserializer = new TaggedJobDeserializer();
 
     public ComputeModuleClient() {
@@ -48,6 +55,9 @@ public final class ComputeModuleClient implements Client {
         this.postRequest = HttpRequest.newBuilder()
                 .header("Module-Auth-Token", moduleAuthToken)
                 .header("Content-Type", "application/octet-stream");
+        this.postSchemasRequest = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:8946/schemas"))
+                .header("Content-Type", "application/json");
         this.client = HttpClient.newBuilder().build();
     }
 
@@ -87,5 +97,50 @@ public final class ComputeModuleClient implements Client {
     }
 
     @Override
-    public void postSchemas(List<FunctionRunnerSchema> functionSchemas) {}
+    public void postSchemas(List<FunctionRunnerSchema> functionSchemas) {
+        log.debug("Posting function schemas", UnsafeArg.of("schemas", functionSchemas));
+        byte[] body;
+        try {
+            body = mapper.writeValueAsBytes(functionSchemas);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize function schemas", e);
+            return;
+        }
+
+        for (int attempt = 0; attempt < POST_SCHEMAS_MAX_ATTEMPTS; attempt++) {
+            try {
+                HttpRequest request = postSchemasRequest
+                        .copy()
+                        .POST(BodyPublishers.ofByteArray(body))
+                        .build();
+                HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+                log.debug(
+                        "POST /schemas response",
+                        SafeArg.of("statusCode", response.statusCode()),
+                        SafeArg.of("body", response.body()));
+                return;
+            } catch (ConnectException e) {
+                long sleepMs = (long) Math.pow(2, attempt) * 1000;
+                log.warn(
+                        "POST /schemas connection refused, retrying",
+                        SafeArg.of("attempt", attempt + 1),
+                        SafeArg.of("sleepMs", sleepMs));
+                try {
+                    Thread.sleep(sleepMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.error("Interrupted while waiting to retry POST /schemas", ie);
+                    return;
+                }
+            } catch (IOException e) {
+                log.error("IO error posting function schemas", e);
+                return;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted while posting function schemas", e);
+                return;
+            }
+        }
+        log.error("Failed to POST /schemas after max attempts", SafeArg.of("attempts", POST_SCHEMAS_MAX_ATTEMPTS));
+    }
 }

--- a/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/ComputeModuleClient.java
@@ -41,7 +41,6 @@ public final class ComputeModuleClient implements Client {
     private static final int POST_SCHEMAS_MAX_ATTEMPTS = 5;
     private static final ObjectMapper mapper = new ObjectMapper().registerModule(new Jdk8Module());
 
-    private final String runtimeHost;
     private final HttpClient client;
     private final HttpRequest getRequest;
     private final HttpRequest.Builder postRequest;
@@ -49,17 +48,12 @@ public final class ComputeModuleClient implements Client {
     private final TaggedJobDeserializer deserializer = new TaggedJobDeserializer();
 
     public ComputeModuleClient() {
-        String moduleAuthToken = EnvVars.Reserved.MODULE_AUTH_TOKEN.get();
-        this.runtimeHost = EnvVars.Reserved.RUNTIME_HOST.get();
         this.getRequest = HttpRequest.newBuilder()
-                .uri(URI.create(String.format("http://%s:8946/job", runtimeHost)))
-                .header("Module-Auth-Token", moduleAuthToken)
+                .uri(URI.create(EnvVars.Reserved.GET_JOB_URI_V2.get()))
                 .build();
-        this.postRequest = HttpRequest.newBuilder()
-                .header("Module-Auth-Token", moduleAuthToken)
-                .header("Content-Type", "application/octet-stream");
+        this.postRequest = HttpRequest.newBuilder().header("Content-Type", "application/octet-stream");
         this.postSchemasRequest = HttpRequest.newBuilder()
-                .uri(URI.create(String.format("http://%s:8946/schemas", runtimeHost)))
+                .uri(URI.create(EnvVars.Reserved.POST_SCHEMA_URI_V2.get()))
                 .header("Content-Type", "application/json");
         this.client = HttpClient.newBuilder().build();
     }
@@ -89,7 +83,7 @@ public final class ComputeModuleClient implements Client {
     public void postResult(String jobId, InputStream result) {
         HttpRequest request = postRequest
                 .copy()
-                .uri(URI.create(String.format("http://%s:8946/results/%s", runtimeHost, jobId)))
+                .uri(URI.create(String.format("%s/%s", EnvVars.Reserved.POST_RESULT_URI_V2.get(), jobId)))
                 .POST(BodyPublishers.ofInputStream(() -> result))
                 .build();
         try {

--- a/lib/src/main/java/com/palantir/computemodules/client/TestClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/TestClient.java
@@ -16,7 +16,9 @@
 package com.palantir.computemodules.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -55,6 +57,9 @@ public final class TestClient implements Client {
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public void postSchemas(List<FunctionRunnerSchema> functionSchemas) {}
 
     /*
      * Executes a test job and returns a result stream

--- a/lib/src/main/java/com/palantir/computemodules/client/TestClient.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/TestClient.java
@@ -59,7 +59,9 @@ public final class TestClient implements Client {
     }
 
     @Override
-    public void postSchemas(List<FunctionRunnerSchema> functionSchemas) {}
+    public void postSchemas(List<FunctionRunnerSchema> _functionSchemas) {
+        // No-op for testing
+    }
 
     /*
      * Executes a test job and returns a result stream

--- a/lib/src/main/java/com/palantir/computemodules/client/config/EnvVars.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/config/EnvVars.java
@@ -27,6 +27,7 @@ public final class EnvVars {
         POST_RESULT_URI(StringEnvVar.of("POST_RESULT_URI")),
         DEFAULT_CA_PATH(StringEnvVar.of("DEFAULT_CA_PATH")),
         MODULE_AUTH_TOKEN(FileEnvVar.of("MODULE_AUTH_TOKEN")),
+        RUNTIME_HOST(StringEnvVar.of("RUNTIME_HOST")),
         ;
 
         public String get() {

--- a/lib/src/main/java/com/palantir/computemodules/client/config/EnvVars.java
+++ b/lib/src/main/java/com/palantir/computemodules/client/config/EnvVars.java
@@ -24,10 +24,15 @@ import java.util.Optional;
 public final class EnvVars {
     public enum Reserved {
         GET_JOB_URI(StringEnvVar.of("GET_JOB_URI")),
+        GET_JOB_URI_V2(StringEnvVar.of("GET_JOB_URI_V2")),
         POST_RESULT_URI(StringEnvVar.of("POST_RESULT_URI")),
+        POST_RESULT_URI_V2(StringEnvVar.of("POST_RESULT_URI_V2")),
+        POST_SCHEMA_URI_V2(StringEnvVar.of("POST_SCHEMA_URI_V2")),
         DEFAULT_CA_PATH(StringEnvVar.of("DEFAULT_CA_PATH")),
         MODULE_AUTH_TOKEN(FileEnvVar.of("MODULE_AUTH_TOKEN")),
         RUNTIME_HOST(StringEnvVar.of("RUNTIME_HOST")),
+        CLIENT_ID(StringEnvVar.of("CLIENT_ID")),
+        CLIENT_SECRET(StringEnvVar.of("CLIENT_SECRET")),
         ;
 
         public String get() {

--- a/lib/src/main/java/com/palantir/computemodules/functions/FunctionRunner.java
+++ b/lib/src/main/java/com/palantir/computemodules/functions/FunctionRunner.java
@@ -43,6 +43,14 @@ public final class FunctionRunner<I, O> {
         this.serializer = serializer;
     }
 
+    public Class<I> inputClass() {
+        return inputType;
+    }
+
+    public Class<O> outputClass() {
+        return outputType;
+    }
+
     @Unsafe
     public Result run(Context context, Object input) {
         I deserializedInput = deserializer.deserialize(input, inputType);

--- a/lib/src/main/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverter.java
+++ b/lib/src/main/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverter.java
@@ -74,7 +74,7 @@ public final class FunctionRunnerSchemaConverter {
 
     private FunctionRunnerSchemaConverter() {}
 
-    public List<QueryRunnerSchema> getFunctionSchemas(Map<String, FunctionRunner<?, ?>> functions) {
+    public static List<QueryRunnerSchema> getFunctionSchemas(Map<String, FunctionRunner<?, ?>> functions) {
         return EntryStream.of(functions)
                 .map(function -> {
                     FunctionRunner<?, ?> functionRunner = function.getValue();

--- a/lib/src/main/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverter.java
+++ b/lib/src/main/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverter.java
@@ -27,14 +27,14 @@ import com.palantir.computemodules.functions.api.DoubleType;
 import com.palantir.computemodules.functions.api.FloatType;
 import com.palantir.computemodules.functions.api.FunctionInputType;
 import com.palantir.computemodules.functions.api.FunctionOutputType;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchemaParseIssue;
 import com.palantir.computemodules.functions.api.InputName;
 import com.palantir.computemodules.functions.api.IntegerType;
 import com.palantir.computemodules.functions.api.ListType;
 import com.palantir.computemodules.functions.api.LongType;
 import com.palantir.computemodules.functions.api.MapType;
 import com.palantir.computemodules.functions.api.OptionalType;
-import com.palantir.computemodules.functions.api.QueryRunnerSchema;
-import com.palantir.computemodules.functions.api.QueryRunnerSchemaParseIssue;
 import com.palantir.computemodules.functions.api.SetType;
 import com.palantir.computemodules.functions.api.ShortType;
 import com.palantir.computemodules.functions.api.SingleOutputType;
@@ -74,13 +74,13 @@ public final class FunctionRunnerSchemaConverter {
 
     private FunctionRunnerSchemaConverter() {}
 
-    public static List<QueryRunnerSchema> getFunctionSchemas(Map<String, FunctionRunner<?, ?>> functions) {
+    public static List<FunctionRunnerSchema> getFunctionSchemas(Map<String, FunctionRunner<?, ?>> functions) {
         return EntryStream.of(functions)
                 .map(function -> {
                     FunctionRunner<?, ?> functionRunner = function.getValue();
                     Optional<Map<String, DataType>> maybeInputTypes = classToDataTypes(functionRunner.inputClass());
                     Optional<DataType> maybeOutputType = classToDataType(functionRunner.outputClass());
-                    List<QueryRunnerSchemaParseIssue> issues = new ArrayList<>();
+                    List<FunctionRunnerSchemaParseIssue> issues = new ArrayList<>();
                     List<FunctionInputType> inputTypes;
                     if (maybeInputTypes.isPresent()) {
                         inputTypes = maybeInputTypes.get().entrySet().stream()
@@ -91,7 +91,7 @@ public final class FunctionRunnerSchemaConverter {
                                         .build())
                                 .toList();
                     } else {
-                        issues.add(QueryRunnerSchemaParseIssue.CANNOT_PARSE_INPUTS);
+                        issues.add(FunctionRunnerSchemaParseIssue.CANNOT_PARSE_INPUTS);
                         inputTypes = new ArrayList<>();
                     }
                     FunctionOutputType outputType;
@@ -100,12 +100,12 @@ public final class FunctionRunnerSchemaConverter {
                                 .dataType(maybeOutputType.get())
                                 .build());
                     } else {
-                        issues.add(QueryRunnerSchemaParseIssue.CANNOT_PARSE_OUTPUT);
+                        issues.add(FunctionRunnerSchemaParseIssue.CANNOT_PARSE_OUTPUT);
                         outputType = FunctionOutputType.single(SingleOutputType.builder()
                                 .dataType(DataType.unknown("unknown", UnknownType.of()))
                                 .build());
                     }
-                    return QueryRunnerSchema.builder()
+                    return FunctionRunnerSchema.builder()
                             .functionName(function.getKey())
                             .output(outputType)
                             .addAllInputs(inputTypes)

--- a/lib/src/main/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverter.java
+++ b/lib/src/main/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverter.java
@@ -1,0 +1,351 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.computemodules.functions.schema;
+
+import com.palantir.computemodules.functions.FunctionRunner;
+import com.palantir.computemodules.functions.api.AnonymousCustomType;
+import com.palantir.computemodules.functions.api.BooleanType;
+import com.palantir.computemodules.functions.api.ByteType;
+import com.palantir.computemodules.functions.api.CustomTypeFieldName;
+import com.palantir.computemodules.functions.api.DataType;
+import com.palantir.computemodules.functions.api.DateType;
+import com.palantir.computemodules.functions.api.DoubleType;
+import com.palantir.computemodules.functions.api.FloatType;
+import com.palantir.computemodules.functions.api.FunctionInputType;
+import com.palantir.computemodules.functions.api.FunctionOutputType;
+import com.palantir.computemodules.functions.api.InputName;
+import com.palantir.computemodules.functions.api.IntegerType;
+import com.palantir.computemodules.functions.api.ListType;
+import com.palantir.computemodules.functions.api.LongType;
+import com.palantir.computemodules.functions.api.MapType;
+import com.palantir.computemodules.functions.api.OptionalType;
+import com.palantir.computemodules.functions.api.QueryRunnerSchema;
+import com.palantir.computemodules.functions.api.QueryRunnerSchemaParseIssue;
+import com.palantir.computemodules.functions.api.SetType;
+import com.palantir.computemodules.functions.api.ShortType;
+import com.palantir.computemodules.functions.api.SingleOutputType;
+import com.palantir.computemodules.functions.api.StringType;
+import com.palantir.computemodules.functions.api.TimestampType;
+import com.palantir.computemodules.functions.api.UnknownType;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.logger.SafeLogger;
+import com.palantir.logsafe.logger.SafeLoggerFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import one.util.streamex.EntryStream;
+
+/**
+ * This utility class handles conversion from a Java {@link Class} to a
+ * {@link DataType} object.
+ */
+public final class FunctionRunnerSchemaConverter {
+    private static final SafeLogger log = SafeLoggerFactory.get(FunctionRunnerSchemaConverter.class);
+    private static final Set<Class<?>> WRAPPER_TYPES = getWrapperTypes();
+    private static final int MAX_OBJECT_DEPTH = 10;
+
+    private FunctionRunnerSchemaConverter() {}
+
+    public List<QueryRunnerSchema> getFunctionSchemas(Map<String, FunctionRunner<?, ?>> functions) {
+        return EntryStream.of(functions)
+                .map(function -> {
+                    FunctionRunner<?, ?> functionRunner = function.getValue();
+                    Optional<Map<String, DataType>> maybeInputTypes = classToDataTypes(functionRunner.inputClass());
+                    Optional<DataType> maybeOutputType = classToDataType(functionRunner.outputClass());
+                    List<QueryRunnerSchemaParseIssue> issues = new ArrayList<>();
+                    List<FunctionInputType> inputTypes;
+                    if (maybeInputTypes.isPresent()) {
+                        inputTypes = maybeInputTypes.get().entrySet().stream()
+                                .map(entry -> FunctionInputType.builder()
+                                        .name(InputName.valueOf(entry.getKey()))
+                                        .dataType(entry.getValue())
+                                        .required(true)
+                                        .build())
+                                .toList();
+                    } else {
+                        issues.add(QueryRunnerSchemaParseIssue.CANNOT_PARSE_INPUTS);
+                        inputTypes = new ArrayList<>();
+                    }
+                    FunctionOutputType outputType;
+                    if (maybeOutputType.isPresent()) {
+                        outputType = FunctionOutputType.single(SingleOutputType.builder()
+                                .dataType(maybeOutputType.get())
+                                .build());
+                    } else {
+                        issues.add(QueryRunnerSchemaParseIssue.CANNOT_PARSE_OUTPUT);
+                        outputType = FunctionOutputType.single(SingleOutputType.builder()
+                                .dataType(DataType.unknown("unknown", UnknownType.of()))
+                                .build());
+                    }
+                    return QueryRunnerSchema.builder()
+                            .functionName(function.getKey())
+                            .output(outputType)
+                            .addAllInputs(inputTypes)
+                            .issues(issues)
+                            .build();
+                })
+                .toList();
+    }
+
+    /**
+     * Converts a Java {@link Class} to an Optional Map where each key represents a field name, and
+     * each value is a {@link DataType} corresponding to the class represented by the original field.
+     * This is used to generate a valid Foundry Function schema, since the input(s) of a Function are represented
+     * as a list of {@link com.palantir.computemodules.functions.api.FunctionInputType} objects.
+     * If the {@link Class} provided is not a complex class, this function will return `Optional.empty()` since there
+     * are no fields to inspect.
+     *
+     * @param clazz the {@link Class} reference to inspect.
+     * @return a `Map` from fieldName -> {@link DataType} for each field of the provided {@link Class}
+     */
+    static Optional<Map<String, DataType>> classToDataTypes(Class<?> clazz) {
+        if (isAtomicType(clazz)) {
+            return Optional.empty();
+        }
+        Map<String, DataType> fieldTypes = new HashMap<>();
+        getFieldsToTraverse(clazz).forEach(field -> {
+            Optional<DataType> fieldType = fieldToDataType(field);
+            if (fieldType.isPresent()) {
+                fieldTypes.put(field.getName(), fieldType.get());
+            } else {
+                fieldTypes.put(
+                        field.getName(),
+                        DataType.unknown(field.getType().getSimpleName().toUpperCase(Locale.ROOT), Optional.empty()));
+            }
+        });
+        return Optional.of(fieldTypes);
+    }
+
+    /**
+     * Converts a Java {@link Class} to a {@link DataType} corresponding to the class represented by the input.
+     *
+     * @param clazz the {@link Class} reference to inspect.
+     * @return a {@link DataType} corresponding to the class provided
+     */
+    static Optional<DataType> classToDataType(Class<?> clazz) {
+        return recClassToDataType(clazz, 0, clazz, new Type[0]);
+    }
+
+    private static Optional<DataType> fieldToDataType(Field field) {
+        Type[] typeArgs = getTypeArgumentsFromField(field);
+        return recClassToDataType(field.getType(), 0, field.getType(), typeArgs);
+    }
+
+    /**
+     * Determines if the given class is an "atomic" (non-complex) type.
+     * This check is needed because Foundry requires a function to take a complex type as input.
+     *
+     * @param clazz the class definition to inspect
+     * @return true if the type is not a complex type (excluding built-in object types)
+     */
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    private static boolean isAtomicType(Class<?> clazz) {
+        if (clazz.isPrimitive()) {
+            return true;
+        } else if (clazz.isArray()) {
+            return true;
+        } else if (clazz.isEnum()) {
+            return true;
+        } else if (Map.class.isAssignableFrom(clazz)) {
+            return true;
+        } else if (Set.class.isAssignableFrom(clazz)) {
+            return true;
+        } else if (List.class.isAssignableFrom(clazz)) {
+            return true;
+        }
+        return WRAPPER_TYPES.contains(clazz);
+    }
+
+    private static Stream<Field> getFieldsToTraverse(Class<?> clazz) {
+        return Arrays.stream(clazz.getDeclaredFields())
+                .filter(field -> !field.isSynthetic() && !Modifier.isStatic(field.getModifiers()));
+    }
+
+    private static Set<Class<?>> getWrapperTypes() {
+        Set<Class<?>> ret = new HashSet<>();
+        ret.add(Integer.class);
+        ret.add(Long.class);
+        ret.add(Double.class);
+        ret.add(Float.class);
+        ret.add(Boolean.class);
+        ret.add(String.class);
+        ret.add(Date.class);
+        ret.add(Byte.class);
+        ret.add(Short.class);
+        ret.add(Timestamp.class);
+        ret.add(Character.class);
+        ret.add(Void.class);
+        return ret;
+    }
+
+    /**
+     * Returns the parameterized types of the underlying {@link Class} of a field if that
+     * underlying {@link Class} is a generic type.
+     * If the underlying {@link Class} is not generic, this method will return an empty Array.
+     *
+     * @param field a field of a complex {@link Class}
+     * @return an Array of {@link Type} references corresponding to the generic parameters of the field's underlying type
+     */
+    private static Type[] getTypeArgumentsFromField(Field field) {
+        Type fieldGenericType = field.getGenericType();
+        TypeVariable<?>[] typeParams = field.getType().getTypeParameters();
+        if (typeParams.length > 0 && fieldGenericType instanceof ParameterizedType parameterizedType) {
+            return parameterizedType.getActualTypeArguments();
+        }
+        return new Type[0];
+    }
+
+    /**
+     * Extracts the raw {@link Class} from a {@link Type}, handling {@link ParameterizedType}.
+     */
+    private static Class<?> getRawClass(Type type) {
+        if (type instanceof Class<?> clazz) {
+            return clazz;
+        } else if (type instanceof ParameterizedType parameterizedType) {
+            return (Class<?>) parameterizedType.getRawType();
+        }
+        return Object.class;
+    }
+
+    /**
+     * Gets the type arguments from a {@link Type} if it's a {@link ParameterizedType}.
+     */
+    private static Type[] getNestedTypeArgs(Type type) {
+        if (type instanceof ParameterizedType parameterizedType) {
+            return parameterizedType.getActualTypeArguments();
+        }
+        return new Type[0];
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    private static Optional<DataType> recClassToDataType(
+            Class<?> clazz, int depth, Class<?> rootClazz, Type[] typeArguments) {
+        // TODO(.): handle binary input
+        if (depth > 0 && clazz == rootClazz) {
+            log.error(
+                    "Detected cyclic DataType",
+                    SafeArg.of("className", clazz.getTypeName()),
+                    SafeArg.of("rootClass", rootClazz.getTypeName()));
+            return Optional.empty();
+        } else if (depth >= MAX_OBJECT_DEPTH) {
+            log.error(
+                    "Java class too deeply nested to be converted to a DataType",
+                    SafeArg.of("className", clazz.getTypeName()),
+                    SafeArg.of("rootClass", rootClazz.getTypeName()),
+                    SafeArg.of("maxDepth", MAX_OBJECT_DEPTH));
+            return Optional.empty();
+        } else if (clazz == Integer.class || clazz == int.class) {
+            return Optional.of(DataType.integer(IntegerType.of()));
+        } else if (clazz == Long.class || clazz == long.class) {
+            return Optional.of(DataType.long_(LongType.of()));
+        } else if (clazz == Double.class || clazz == double.class) {
+            return Optional.of(DataType.double_(DoubleType.of()));
+        } else if (clazz == Float.class || clazz == float.class) {
+            return Optional.of(DataType.float_(FloatType.of()));
+        } else if (clazz == Boolean.class || clazz == boolean.class) {
+            return Optional.of(DataType.boolean_(BooleanType.of()));
+        } else if (clazz == String.class) {
+            return Optional.of(DataType.string(StringType.of()));
+        } else if (clazz == Date.class) {
+            return Optional.of(DataType.date(DateType.of()));
+        } else if (clazz == Byte.class || clazz == byte.class) {
+            return Optional.of(DataType.byte_(ByteType.of()));
+        } else if (clazz == Short.class || clazz == short.class) {
+            return Optional.of(DataType.short_(ShortType.of()));
+        } else if (clazz == Timestamp.class) {
+            return Optional.of(DataType.timestamp(TimestampType.of()));
+        } else if (clazz.isArray()) {
+            Optional<DataType> componentType =
+                    recClassToDataType(clazz.getComponentType(), depth + 1, rootClazz, new Type[0]);
+            return componentType.map(dataType -> DataType.list(ListType.of(dataType)));
+        } else if (Map.class.isAssignableFrom(clazz)) {
+            Optional<DataType> maybeKeyType = Optional.empty();
+            Optional<DataType> maybeValueType = Optional.empty();
+            if (typeArguments.length == 2) {
+                maybeKeyType = recClassToDataType(
+                        getRawClass(typeArguments[0]), depth + 1, rootClazz, getNestedTypeArgs(typeArguments[0]));
+                maybeValueType = recClassToDataType(
+                        getRawClass(typeArguments[1]), depth + 1, rootClazz, getNestedTypeArgs(typeArguments[1]));
+            }
+            DataType keyType = maybeKeyType.orElseGet(() -> DataType.unknown("key", Optional.empty()));
+            DataType valueType = maybeValueType.orElseGet(() -> DataType.unknown("value", Optional.empty()));
+            return Optional.of(DataType.map(MapType.of(keyType, valueType)));
+        } else if (clazz == Optional.class) {
+            Optional<DataType> maybeParamType = Optional.empty();
+            if (typeArguments.length > 0) {
+                maybeParamType = recClassToDataType(
+                        getRawClass(typeArguments[0]), depth + 1, rootClazz, getNestedTypeArgs(typeArguments[0]));
+            }
+            DataType paramType = maybeParamType.orElseGet(() -> DataType.unknown("value", Optional.empty()));
+            return Optional.of(DataType.optionalType(OptionalType.of(paramType)));
+        } else if (List.class.isAssignableFrom(clazz)) {
+            Optional<DataType> maybeParamType = Optional.empty();
+            if (typeArguments.length > 0) {
+                maybeParamType = recClassToDataType(
+                        getRawClass(typeArguments[0]), depth + 1, rootClazz, getNestedTypeArgs(typeArguments[0]));
+            }
+            DataType paramType = maybeParamType.orElseGet(() -> DataType.unknown("value", Optional.empty()));
+            return Optional.of(DataType.list(ListType.of(paramType)));
+        } else if (Set.class.isAssignableFrom(clazz)) {
+            Optional<DataType> maybeParamType = Optional.empty();
+            if (typeArguments.length > 0) {
+                maybeParamType = recClassToDataType(
+                        getRawClass(typeArguments[0]), depth + 1, rootClazz, getNestedTypeArgs(typeArguments[0]));
+            }
+            DataType paramType = maybeParamType.orElseGet(() -> DataType.unknown("value", Optional.empty()));
+            return Optional.of(DataType.set(SetType.of(paramType)));
+        } else {
+            Map<CustomTypeFieldName, DataType> fieldsAsDataType = new HashMap<>();
+            getFieldsToTraverse(clazz).forEach(field -> {
+                CustomTypeFieldName fName = CustomTypeFieldName.of(field.getName());
+                Type[] typeArgs = getTypeArgumentsFromField(field);
+                Optional<DataType> dataType = recClassToDataType(field.getType(), depth + 1, rootClazz, typeArgs);
+                if (dataType.isPresent()) {
+                    fieldsAsDataType.put(fName, dataType.get());
+                } else {
+                    log.error(
+                            "A member of this Java class was unable to be converted to a DataType.",
+                            SafeArg.of("className", clazz.getTypeName()),
+                            SafeArg.of("fieldName", field.getName()),
+                            SafeArg.of("childClassName", field.getType().getTypeName()),
+                            SafeArg.of("rootClass", rootClazz.getTypeName()));
+                    // Casting fieldType toUpperCase to avoid `provided type is known` error
+                    fieldsAsDataType.put(
+                            fName,
+                            DataType.unknown(
+                                    field.getType().getSimpleName().toUpperCase(Locale.ROOT), Optional.empty()));
+                }
+            });
+            return Optional.of(DataType.anonymousCustomType(
+                    AnonymousCustomType.builder().fields(fieldsAsDataType).build()));
+        }
+    }
+}

--- a/lib/src/test/java/com/palantir/computemodules/ComputeModuleTest.java
+++ b/lib/src/test/java/com/palantir/computemodules/ComputeModuleTest.java
@@ -16,23 +16,31 @@
 package com.palantir.computemodules;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.palantir.computemodules.client.TestClient;
 import com.palantir.computemodules.functions.Context;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class ComputeModuleTest {
 
     private static final ListeningExecutorService executor =
             MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1));
-    private static final TestClient testClient = new TestClient();
+    private static final TestClient testClient = spy(new TestClient());
     private static final ComputeModule cm = ComputeModule.builder()
             .add(ComputeModuleTest::dub, Integer.class, Integer.class, "dub")
             .add(ComputeModuleTest::hello, String.class, String.class, "hello")
@@ -44,6 +52,20 @@ class ComputeModuleTest {
     @BeforeAll
     static void before() {
         executor.execute(cm::start);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void test_postSchemas_called_on_startup() {
+        ArgumentCaptor<List<FunctionRunnerSchema>> captor = ArgumentCaptor.forClass(List.class);
+        verify(testClient, timeout(1000)).postSchemas(captor.capture());
+
+        List<FunctionRunnerSchema> schemas = captor.getValue();
+        assertThat(schemas).hasSize(4);
+
+        Set<String> functionNames =
+                schemas.stream().map(FunctionRunnerSchema::getFunctionName).collect(Collectors.toSet());
+        assertThat(functionNames).containsExactlyInAnyOrder("dub", "hello", "mult", "error");
     }
 
     @Test

--- a/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
+++ b/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
@@ -366,8 +366,8 @@ class FunctionRunnerSchemaConverterTest {
         List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(2);
-        Set<String> functionNames =
-                new HashSet<>(schemas.stream().map(FunctionRunnerSchema::getFunctionName).toList());
+        Set<String> functionNames = new HashSet<>(
+                schemas.stream().map(FunctionRunnerSchema::getFunctionName).toList());
         assertThat(functionNames).containsExactlyInAnyOrder("function1", "function2");
     }
 

--- a/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
+++ b/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
@@ -27,16 +27,15 @@ import com.palantir.computemodules.functions.api.DataType;
 import com.palantir.computemodules.functions.api.DateType;
 import com.palantir.computemodules.functions.api.DoubleType;
 import com.palantir.computemodules.functions.api.FloatType;
+import com.palantir.computemodules.functions.api.FunctionInputType;
+import com.palantir.computemodules.functions.api.FunctionOutputType;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchema;
+import com.palantir.computemodules.functions.api.FunctionRunnerSchemaParseIssue;
 import com.palantir.computemodules.functions.api.IntegerType;
 import com.palantir.computemodules.functions.api.ListType;
 import com.palantir.computemodules.functions.api.LongType;
 import com.palantir.computemodules.functions.api.MapType;
 import com.palantir.computemodules.functions.api.OptionalType;
-import com.palantir.computemodules.functions.api.FunctionInputType;
-import com.palantir.computemodules.functions.api.FunctionOutputType;
-import com.palantir.computemodules.functions.api.InputName;
-import com.palantir.computemodules.functions.api.QueryRunnerSchema;
-import com.palantir.computemodules.functions.api.QueryRunnerSchemaParseIssue;
 import com.palantir.computemodules.functions.api.SetType;
 import com.palantir.computemodules.functions.api.ShortType;
 import com.palantir.computemodules.functions.api.StringType;
@@ -334,10 +333,10 @@ class FunctionRunnerSchemaConverterTest {
         Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
         functions.put("testFunction", createMockFunctionRunner(SimpleInput.class, SimpleOutput.class));
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(1);
-        QueryRunnerSchema schema = schemas.get(0);
+        FunctionRunnerSchema schema = schemas.get(0);
         assertThat(schema.getFunctionName()).isEqualTo("testFunction");
         assertThat(schema.getIssues()).isEmpty();
 
@@ -364,11 +363,11 @@ class FunctionRunnerSchemaConverterTest {
         functions.put("function1", createMockFunctionRunner(SimpleInput.class, String.class));
         functions.put("function2", createMockFunctionRunner(ParentTestClass.class, Integer.class));
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(2);
         Set<String> functionNames =
-                new HashSet<>(schemas.stream().map(QueryRunnerSchema::getFunctionName).toList());
+                new HashSet<>(schemas.stream().map(FunctionRunnerSchema::getFunctionName).toList());
         assertThat(functionNames).containsExactlyInAnyOrder("function1", "function2");
     }
 
@@ -376,7 +375,7 @@ class FunctionRunnerSchemaConverterTest {
     public void testGetFunctionSchemasWithEmptyMap() {
         Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).isEmpty();
     }
@@ -386,12 +385,12 @@ class FunctionRunnerSchemaConverterTest {
         Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
         functions.put("atomicInputFunction", createMockFunctionRunner(String.class, SimpleOutput.class));
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(1);
-        QueryRunnerSchema schema = schemas.get(0);
+        FunctionRunnerSchema schema = schemas.get(0);
         assertThat(schema.getFunctionName()).isEqualTo("atomicInputFunction");
-        assertThat(schema.getIssues()).containsExactly(QueryRunnerSchemaParseIssue.CANNOT_PARSE_INPUTS);
+        assertThat(schema.getIssues()).containsExactly(FunctionRunnerSchemaParseIssue.CANNOT_PARSE_INPUTS);
         assertThat(schema.getInputs()).isEmpty();
     }
 
@@ -400,10 +399,10 @@ class FunctionRunnerSchemaConverterTest {
         Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
         functions.put("testFunction", createMockFunctionRunner(SimpleInput.class, String.class));
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(1);
-        QueryRunnerSchema schema = schemas.get(0);
+        FunctionRunnerSchema schema = schemas.get(0);
         for (FunctionInputType input : schema.getInputs()) {
             assertThat(input.getRequired()).isTrue();
         }
@@ -414,10 +413,10 @@ class FunctionRunnerSchemaConverterTest {
         Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
         functions.put("stringOutputFunction", createMockFunctionRunner(SimpleInput.class, String.class));
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(1);
-        QueryRunnerSchema schema = schemas.get(0);
+        FunctionRunnerSchema schema = schemas.get(0);
         FunctionOutputType outputType = schema.getOutput();
         DataType outputDataType = outputType.accept(FunctionOutputType.Visitor.<DataType>builder()
                 .single(single -> single.getDataType())
@@ -432,10 +431,10 @@ class FunctionRunnerSchemaConverterTest {
         Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
         functions.put("complexOutputFunction", createMockFunctionRunner(SimpleInput.class, SimpleOutput.class));
 
-        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+        List<FunctionRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
 
         assertThat(schemas).hasSize(1);
-        QueryRunnerSchema schema = schemas.get(0);
+        FunctionRunnerSchema schema = schemas.get(0);
         FunctionOutputType outputType = schema.getOutput();
         DataType outputDataType = outputType.accept(FunctionOutputType.Visitor.<DataType>builder()
                 .single(single -> single.getDataType())

--- a/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
+++ b/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
@@ -16,8 +16,9 @@
 
 package com.palantir.computemodules.functions.schema;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.palantir.computemodules.functions.FunctionRunner;
 import com.palantir.computemodules.functions.api.AnonymousCustomType;
 import com.palantir.computemodules.functions.api.BooleanType;
 import com.palantir.computemodules.functions.api.ByteType;
@@ -31,9 +32,16 @@ import com.palantir.computemodules.functions.api.ListType;
 import com.palantir.computemodules.functions.api.LongType;
 import com.palantir.computemodules.functions.api.MapType;
 import com.palantir.computemodules.functions.api.OptionalType;
+import com.palantir.computemodules.functions.api.FunctionInputType;
+import com.palantir.computemodules.functions.api.FunctionOutputType;
+import com.palantir.computemodules.functions.api.InputName;
+import com.palantir.computemodules.functions.api.QueryRunnerSchema;
+import com.palantir.computemodules.functions.api.QueryRunnerSchemaParseIssue;
 import com.palantir.computemodules.functions.api.SetType;
 import com.palantir.computemodules.functions.api.ShortType;
 import com.palantir.computemodules.functions.api.StringType;
+import com.palantir.computemodules.functions.serde.Deserializer;
+import com.palantir.computemodules.functions.serde.Serializer;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -288,5 +296,159 @@ class FunctionRunnerSchemaConverterTest {
         DataType expected = DataType.anonymousCustomType(
                 AnonymousCustomType.builder().fields(expectedFields).build());
         assertThat(dType.orElseThrow()).isEqualTo(expected);
+    }
+
+    // Test input/output classes for getFunctionSchemas tests
+    static class SimpleInput {
+        public final String name;
+        public final int value;
+
+        SimpleInput(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+    static class SimpleOutput {
+        public final boolean success;
+        public final String message;
+
+        SimpleOutput(boolean success, String message) {
+            this.success = success;
+            this.message = message;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <I, O> FunctionRunner<I, O> createMockFunctionRunner(Class<I> inputClass, Class<O> outputClass) {
+        return new FunctionRunner<>(
+                (_context, _input) -> null,
+                inputClass,
+                outputClass,
+                (Deserializer<I>) (input, _type) -> (I) input,
+                (Serializer<O>) (_jobId, _output) -> null);
+    }
+
+    @Test
+    public void testGetFunctionSchemasWithSingleFunction() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+        functions.put("testFunction", createMockFunctionRunner(SimpleInput.class, SimpleOutput.class));
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).hasSize(1);
+        QueryRunnerSchema schema = schemas.get(0);
+        assertThat(schema.getFunctionName()).isEqualTo("testFunction");
+        assertThat(schema.getIssues()).isEmpty();
+
+        // Verify inputs
+        List<FunctionInputType> inputs = schema.getInputs();
+        assertThat(inputs).hasSize(2);
+        Set<String> inputNames =
+                new HashSet<>(inputs.stream().map(i -> i.getName().get()).toList());
+        assertThat(inputNames).containsExactlyInAnyOrder("name", "value");
+
+        // Verify output is a single output type
+        FunctionOutputType outputType = schema.getOutput();
+        DataType outputDataType = outputType.accept(FunctionOutputType.Visitor.<DataType>builder()
+                .single(single -> single.getDataType())
+                .void_(_void -> null)
+                .throwOnUnknown()
+                .build());
+        assertThat(outputDataType).isNotNull();
+    }
+
+    @Test
+    public void testGetFunctionSchemasWithMultipleFunctions() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+        functions.put("function1", createMockFunctionRunner(SimpleInput.class, String.class));
+        functions.put("function2", createMockFunctionRunner(ParentTestClass.class, Integer.class));
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).hasSize(2);
+        Set<String> functionNames =
+                new HashSet<>(schemas.stream().map(QueryRunnerSchema::getFunctionName).toList());
+        assertThat(functionNames).containsExactlyInAnyOrder("function1", "function2");
+    }
+
+    @Test
+    public void testGetFunctionSchemasWithEmptyMap() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).isEmpty();
+    }
+
+    @Test
+    public void testGetFunctionSchemasWithAtomicInputType() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+        functions.put("atomicInputFunction", createMockFunctionRunner(String.class, SimpleOutput.class));
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).hasSize(1);
+        QueryRunnerSchema schema = schemas.get(0);
+        assertThat(schema.getFunctionName()).isEqualTo("atomicInputFunction");
+        assertThat(schema.getIssues()).containsExactly(QueryRunnerSchemaParseIssue.CANNOT_PARSE_INPUTS);
+        assertThat(schema.getInputs()).isEmpty();
+    }
+
+    @Test
+    public void testGetFunctionSchemasInputsAreMarkedRequired() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+        functions.put("testFunction", createMockFunctionRunner(SimpleInput.class, String.class));
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).hasSize(1);
+        QueryRunnerSchema schema = schemas.get(0);
+        for (FunctionInputType input : schema.getInputs()) {
+            assertThat(input.getRequired()).isTrue();
+        }
+    }
+
+    @Test
+    public void testGetFunctionSchemasOutputTypeCorrectlyConverted() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+        functions.put("stringOutputFunction", createMockFunctionRunner(SimpleInput.class, String.class));
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).hasSize(1);
+        QueryRunnerSchema schema = schemas.get(0);
+        FunctionOutputType outputType = schema.getOutput();
+        DataType outputDataType = outputType.accept(FunctionOutputType.Visitor.<DataType>builder()
+                .single(single -> single.getDataType())
+                .void_(_void -> null)
+                .throwOnUnknown()
+                .build());
+        assertThat(outputDataType).isEqualTo(DataType.string(StringType.of()));
+    }
+
+    @Test
+    public void testGetFunctionSchemasWithComplexOutputType() {
+        Map<String, FunctionRunner<?, ?>> functions = new HashMap<>();
+        functions.put("complexOutputFunction", createMockFunctionRunner(SimpleInput.class, SimpleOutput.class));
+
+        List<QueryRunnerSchema> schemas = FunctionRunnerSchemaConverter.getFunctionSchemas(functions);
+
+        assertThat(schemas).hasSize(1);
+        QueryRunnerSchema schema = schemas.get(0);
+        FunctionOutputType outputType = schema.getOutput();
+        DataType outputDataType = outputType.accept(FunctionOutputType.Visitor.<DataType>builder()
+                .single(single -> single.getDataType())
+                .void_(_void -> null)
+                .throwOnUnknown()
+                .build());
+
+        // Verify output is an anonymous custom type with the expected fields
+        Map<CustomTypeFieldName, DataType> expectedFields = new HashMap<>();
+        expectedFields.put(CustomTypeFieldName.of("success"), DataType.boolean_(BooleanType.of()));
+        expectedFields.put(CustomTypeFieldName.of("message"), DataType.string(StringType.of()));
+        DataType expectedOutput = DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(expectedFields).build());
+        assertThat(outputDataType).isEqualTo(expectedOutput);
     }
 }

--- a/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
+++ b/lib/src/test/java/com/palantir/computemodules/functions/schema/FunctionRunnerSchemaConverterTest.java
@@ -1,0 +1,292 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.computemodules.functions.schema;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.palantir.computemodules.functions.api.AnonymousCustomType;
+import com.palantir.computemodules.functions.api.BooleanType;
+import com.palantir.computemodules.functions.api.ByteType;
+import com.palantir.computemodules.functions.api.CustomTypeFieldName;
+import com.palantir.computemodules.functions.api.DataType;
+import com.palantir.computemodules.functions.api.DateType;
+import com.palantir.computemodules.functions.api.DoubleType;
+import com.palantir.computemodules.functions.api.FloatType;
+import com.palantir.computemodules.functions.api.IntegerType;
+import com.palantir.computemodules.functions.api.ListType;
+import com.palantir.computemodules.functions.api.LongType;
+import com.palantir.computemodules.functions.api.MapType;
+import com.palantir.computemodules.functions.api.OptionalType;
+import com.palantir.computemodules.functions.api.SetType;
+import com.palantir.computemodules.functions.api.ShortType;
+import com.palantir.computemodules.functions.api.StringType;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("JavaUtilDate") // Testing Date type handling in schema converter
+class FunctionRunnerSchemaConverterTest {
+    static class ChildTestClass {
+        public final boolean childFieldOne;
+        public final Double childFieldTwo;
+        public final Date[] childFieldThree;
+        static ChildTestClass shouldbeIgnored = new ChildTestClass(true, 2.0, new Date[] {new Date()});
+
+        ChildTestClass(boolean childFieldOne, Double childFieldTwo, Date[] childFieldThree) {
+            this.childFieldOne = childFieldOne;
+            this.childFieldTwo = childFieldTwo;
+            this.childFieldThree = childFieldThree;
+        }
+    }
+
+    static class ParentTestClass {
+        private final int parentFieldOne;
+        private final String parentFieldTwo;
+        private final ChildTestClass child;
+
+        ParentTestClass(int parentFieldOne, String parentFieldTwo, ChildTestClass child) {
+            this.parentFieldOne = parentFieldOne;
+            this.parentFieldTwo = parentFieldTwo;
+            this.child = child;
+        }
+
+        public int getParentFieldOne() {
+            return parentFieldOne;
+        }
+
+        public String getParentFieldTwo() {
+            return parentFieldTwo;
+        }
+
+        public ChildTestClass getChild() {
+            return child;
+        }
+    }
+
+    static class RecursiveTestClass {
+        public final RecursiveTestClass child;
+
+        RecursiveTestClass(RecursiveTestClass child) {
+            this.child = child;
+        }
+    }
+
+    record TestRecord(
+            long fieldOne, float fieldTwo, byte fieldThree, short fieldFour, SortedMap<String, String> fieldFive) {}
+
+    static class TestGenerics {
+        public final boolean nonGenericField;
+        public final List<Integer> intList;
+        public final Optional<String> optionalString;
+        public final Map<String, Date> stringMap;
+        public final Set<Byte> byteSet;
+
+        TestGenerics(
+                boolean nonGenericField,
+                List<Integer> intList,
+                Optional<String> optionalString,
+                Map<String, Date> stringMap,
+                Set<Byte> byteSet) {
+            this.intList = intList;
+            this.optionalString = optionalString;
+            this.nonGenericField = nonGenericField;
+            this.stringMap = stringMap;
+            this.byteSet = byteSet;
+        }
+    }
+
+    static class TestNestedGenerics {
+        public final List<Map<String, String>> rows;
+
+        TestNestedGenerics(List<Map<String, String>> rows) {
+            this.rows = rows;
+        }
+    }
+
+    private static DataType expectedChildTestClassOutput() {
+        Map<CustomTypeFieldName, DataType> childFields = new HashMap<>();
+        childFields.put(CustomTypeFieldName.of("childFieldOne"), DataType.boolean_(BooleanType.of()));
+        childFields.put(CustomTypeFieldName.of("childFieldTwo"), DataType.double_(DoubleType.of()));
+        childFields.put(
+                CustomTypeFieldName.of("childFieldThree"), DataType.list(ListType.of(DataType.date(DateType.of()))));
+        return DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(childFields).build());
+    }
+
+    private static DataType getExpectedOutput() {
+        Map<CustomTypeFieldName, DataType> parentFields = new HashMap<>();
+        parentFields.put(CustomTypeFieldName.of("parentFieldOne"), DataType.integer(IntegerType.of()));
+        parentFields.put(CustomTypeFieldName.of("parentFieldTwo"), DataType.string(StringType.of()));
+        parentFields.put(CustomTypeFieldName.of("child"), expectedChildTestClassOutput());
+        return DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(parentFields).build());
+    }
+
+    private static DataType getExpectedRecordOutput() {
+        Map<CustomTypeFieldName, DataType> typeFields = new HashMap<>();
+        typeFields.put(CustomTypeFieldName.of("fieldOne"), DataType.long_(LongType.of()));
+        typeFields.put(CustomTypeFieldName.of("fieldTwo"), DataType.float_(FloatType.of()));
+        typeFields.put(CustomTypeFieldName.of("fieldThree"), DataType.byte_(ByteType.of()));
+        typeFields.put(CustomTypeFieldName.of("fieldFour"), DataType.short_(ShortType.of()));
+        typeFields.put(
+                CustomTypeFieldName.of("fieldFive"),
+                DataType.map(MapType.of(DataType.string(StringType.of()), DataType.string(StringType.of()))));
+        return DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(typeFields).build());
+    }
+
+    private static DataType getExpectedRecursiveOutput() {
+        Map<CustomTypeFieldName, DataType> typeFields = new HashMap<>();
+        typeFields.put(CustomTypeFieldName.of("child"), DataType.unknown("RECURSIVETESTCLASS", Optional.empty()));
+        return DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(typeFields).build());
+    }
+
+    private static DataType getExpectedGenericOutput() {
+        Map<CustomTypeFieldName, DataType> typeFields = new HashMap<>();
+        typeFields.put(CustomTypeFieldName.of("nonGenericField"), DataType.boolean_(BooleanType.of()));
+        typeFields.put(
+                CustomTypeFieldName.of("intList"), DataType.list(ListType.of(DataType.integer(IntegerType.of()))));
+        typeFields.put(
+                CustomTypeFieldName.of("optionalString"),
+                DataType.optionalType(OptionalType.of(DataType.string(StringType.of()))));
+        typeFields.put(
+                CustomTypeFieldName.of("stringMap"),
+                DataType.map(MapType.of(DataType.string(StringType.of()), DataType.date(DateType.of()))));
+        typeFields.put(CustomTypeFieldName.of("byteSet"), DataType.set(SetType.of(DataType.byte_(ByteType.of()))));
+        return DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(typeFields).build());
+    }
+
+    @Test
+    public void testClassToDataType() {
+        ChildTestClass child = new ChildTestClass(false, 20.0, new Date[] {new Date()});
+        ParentTestClass parent = new ParentTestClass(0, "parentFieldOne", child);
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(parent.getClass());
+        assertThat(dType).isNotEmpty();
+        assertThat(dType.orElseThrow()).isEqualTo(getExpectedOutput());
+    }
+
+    @Test
+    public void testClassToDataTypes() {
+        ChildTestClass child = new ChildTestClass(false, 20.0, new Date[] {new Date()});
+        ParentTestClass parent = new ParentTestClass(0, "parentFieldOne", child);
+        Optional<Map<String, DataType>> dTypes = FunctionRunnerSchemaConverter.classToDataTypes(parent.getClass());
+        assertThat(dTypes).isNotEmpty();
+        assertThat(dTypes.orElseThrow().size()).isEqualTo(3);
+        assertThat(dTypes.orElseThrow().keySet())
+                .isEqualTo(new HashSet<>(Arrays.asList("parentFieldOne", "parentFieldTwo", "child")));
+        assertThat(dTypes.orElseThrow().get("parentFieldOne")).isEqualTo(DataType.integer(IntegerType.of()));
+        assertThat(dTypes.orElseThrow().get("parentFieldTwo")).isEqualTo(DataType.string(StringType.of()));
+        assertThat(dTypes.orElseThrow().get("child")).isEqualTo(expectedChildTestClassOutput());
+    }
+
+    @Test
+    public void testRecordToDataType() {
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(TestRecord.class);
+        assertThat(dType).isNotEmpty();
+        assertThat(dType.orElseThrow()).isEqualTo(getExpectedRecordOutput());
+    }
+
+    @Test
+    public void testGenericsToDataType() {
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(TestGenerics.class);
+        assertThat(dType).isNotEmpty();
+        assertThat(dType.orElseThrow()).isEqualTo(getExpectedGenericOutput());
+    }
+
+    @Test
+    public void testSimpleClassToDataType() {
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(Integer.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.integer(IntegerType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(int.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.integer(IntegerType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(Long.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.long_(LongType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(long.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.long_(LongType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(Double.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.double_(DoubleType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(double.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.double_(DoubleType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(Float.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.float_(FloatType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(float.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.float_(FloatType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(Boolean.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.boolean_(BooleanType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(float.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.float_(FloatType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(String.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.string(StringType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(Date.class);
+        assertThat(dType.orElseThrow()).isEqualTo(DataType.date(DateType.of()));
+
+        dType = FunctionRunnerSchemaConverter.classToDataType(Optional.class);
+        assertThat(dType.orElseThrow())
+                .isEqualTo(DataType.optionalType(OptionalType.of(DataType.unknown("value", Optional.empty()))));
+    }
+
+    @Test
+    public void testRecursiveClassToDataType() {
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(RecursiveTestClass.class);
+        assertThat(dType).isNotEmpty();
+        assertThat(dType.orElseThrow()).isEqualTo(getExpectedRecursiveOutput());
+    }
+
+    @Test
+    public void testNonArrayCollectionFailure() {
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(List.class);
+        assertThat(dType.orElseThrow())
+                .isEqualTo(DataType.list(ListType.of(DataType.unknown("value", Optional.empty()))));
+    }
+
+    @Test
+    public void testNestedGenericsToDataType() {
+        Optional<DataType> dType = FunctionRunnerSchemaConverter.classToDataType(TestNestedGenerics.class);
+        assertThat(dType).isNotEmpty();
+        Map<CustomTypeFieldName, DataType> expectedFields = new HashMap<>();
+        expectedFields.put(
+                CustomTypeFieldName.of("rows"),
+                DataType.list(ListType.of(
+                        DataType.map(MapType.of(DataType.string(StringType.of()), DataType.string(StringType.of()))))));
+        DataType expected = DataType.anonymousCustomType(
+                AnonymousCustomType.builder().fields(expectedFields).build());
+        assertThat(dType.orElseThrow()).isEqualTo(expected);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,4 +16,5 @@ apply plugin: 'com.palantir.jdks.settings'
 rootProject.name = 'java-compute-module'
 
 include 'lib'
-
+include 'lib-api'
+include 'lib-api:lib-api-objects'

--- a/versions.lock
+++ b/versions.lock
@@ -2,9 +2,11 @@
 
 com.fasterxml.jackson.core:jackson-annotations:2.21 (6 constraints: 9e592179)
 
-com.fasterxml.jackson.core:jackson-core:2.21.0 (3 constraints: 0d390d0e)
+com.fasterxml.jackson.core:jackson-core:2.21.0 (4 constraints: 074ff901)
 
-com.fasterxml.jackson.core:jackson-databind:2.21.0 (5 constraints: 8e4963a8)
+com.fasterxml.jackson.core:jackson-databind:2.21.0 (6 constraints: 885fd3dc)
+
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.21.0 (1 constraints: 3c05443b)
 
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.0 (1 constraints: 11051436)
 

--- a/versions.lock
+++ b/versions.lock
@@ -40,6 +40,8 @@ com.palantir.tokens:auth-tokens:3.21.0 (1 constraints: 1e1097a9)
 
 com.palantir.tritium:tritium-ids:0.122.0 (1 constraints: f80f88a6)
 
+one.util:streamex:0.8.4 (1 constraints: 0e050736)
+
 org.eclipse.collections:eclipse-collections:13.0.0 (1 constraints: 1c1091a9)
 
 org.eclipse.collections:eclipse-collections-api:13.0.0 (2 constraints: fa22df26)
@@ -56,7 +58,9 @@ org.slf4j:slf4j-api:2.0.17 (2 constraints: 4f1e7197)
 
 [Test dependencies]
 
-net.bytebuddy:byte-buddy:1.18.3 (1 constraints: 530b55df)
+net.bytebuddy:byte-buddy:1.18.3 (2 constraints: 9c16b43e)
+
+net.bytebuddy:byte-buddy-agent:1.17.7 (1 constraints: 4a0b4ede)
 
 org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
 
@@ -64,7 +68,7 @@ org.assertj:assertj-core:3.27.7 (1 constraints: 4505553b)
 
 org.junit.jupiter:junit-jupiter:6.0.2 (1 constraints: 49070b70)
 
-org.junit.jupiter:junit-jupiter-api:6.0.2 (3 constraints: 612f63d9)
+org.junit.jupiter:junit-jupiter-api:6.0.2 (4 constraints: 583e9039)
 
 org.junit.jupiter:junit-jupiter-engine:6.0.2 (1 constraints: 050ecc3b)
 
@@ -75,5 +79,11 @@ org.junit.platform:junit-platform-commons:6.0.2 (2 constraints: d7207a4a)
 org.junit.platform:junit-platform-engine:6.0.2 (2 constraints: ef221108)
 
 org.junit.platform:junit-platform-launcher:6.0.2 (1 constraints: 0a050b36)
+
+org.mockito:mockito-core:5.21.0 (2 constraints: 2c146a86)
+
+org.mockito:mockito-junit-jupiter:5.21.0 (1 constraints: 3a05483b)
+
+org.objenesis:objenesis:3.3 (1 constraints: b20a14bd)
 
 org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)

--- a/versions.lock
+++ b/versions.lock
@@ -1,38 +1,56 @@
 # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
 
-com.fasterxml.jackson.core:jackson-annotations:2.21 (3 constraints: 0d2d05a7)
+com.fasterxml.jackson.core:jackson-annotations:2.21 (6 constraints: 9e592179)
 
-com.fasterxml.jackson.core:jackson-core:2.21.0 (2 constraints: f128e7df)
+com.fasterxml.jackson.core:jackson-core:2.21.0 (3 constraints: 0d390d0e)
 
-com.fasterxml.jackson.core:jackson-databind:2.21.0 (2 constraints: a81b8ba7)
+com.fasterxml.jackson.core:jackson-databind:2.21.0 (5 constraints: 8e4963a8)
 
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.0 (1 constraints: 11051436)
 
-com.google.errorprone:error_prone_annotations:2.41.0 (5 constraints: db48a599)
+com.google.code.findbugs:jsr305:3.0.2 (1 constraints: 980fcc86)
+
+com.google.errorprone:error_prone_annotations:2.41.0 (7 constraints: 8e6808be)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
-com.google.guava:guava:33.5.0-jre (1 constraints: ab068053)
+com.google.guava:guava:33.5.0-jre (2 constraints: a4167e1d)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
 com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
-com.palantir.safe-logging:logger:3.11.0 (1 constraints: 3705383b)
+com.palantir.conjure.java:conjure-lib:8.69.0 (1 constraints: 3e055d3b)
+
+com.palantir.conjure.java.api:errors:2.68.0 (1 constraints: 2810b6a9)
+
+com.palantir.ri:resource-identifier:2.12.0 (1 constraints: 1d1090a9)
+
+com.palantir.safe-logging:logger:3.11.0 (3 constraints: 6d21659c)
 
 com.palantir.safe-logging:logger-slf4j:3.11.0 (1 constraints: 300e8a50)
 
 com.palantir.safe-logging:logger-spi:3.11.0 (2 constraints: 6f1e0ab0)
 
-com.palantir.safe-logging:preconditions:3.11.0 (1 constraints: 3705383b)
+com.palantir.safe-logging:preconditions:3.11.0 (6 constraints: 8c504e3d)
 
-com.palantir.safe-logging:safe-logging:3.11.0 (3 constraints: 082f2ef9)
+com.palantir.safe-logging:safe-logging:3.11.0 (6 constraints: 275ea724)
 
-org.jetbrains:annotations:26.0.2 (1 constraints: 36116fd1)
+com.palantir.tokens:auth-tokens:3.21.0 (1 constraints: 1e1097a9)
 
-org.jspecify:jspecify:1.0.0 (7 constraints: 5370d26f)
+com.palantir.tritium:tritium-ids:0.122.0 (1 constraints: f80f88a6)
 
-org.slf4j:slf4j-api:2.0.17 (1 constraints: 471091b6)
+org.eclipse.collections:eclipse-collections:13.0.0 (1 constraints: 1c1091a9)
+
+org.eclipse.collections:eclipse-collections-api:13.0.0 (2 constraints: fa22df26)
+
+org.immutables:value:2.12.1 (1 constraints: c90f9796)
+
+org.jetbrains:annotations:26.0.2 (3 constraints: 3826c998)
+
+org.jspecify:jspecify:1.0.0 (8 constraints: ae7f08eb)
+
+org.slf4j:slf4j-api:2.0.17 (2 constraints: 4f1e7197)
 
 
 

--- a/versions.props
+++ b/versions.props
@@ -6,3 +6,5 @@ org.junit.jupiter:* = 6.0.2
 org.junit.platform:* = 6.0.2
 org.slf4j:* = 2.0.17
 com.palantir.safe-logging:* = 3.11.0
+com.palantir.conjure:conjure = 4.54.0
+com.palantir.conjure.java:* = 8.69.0

--- a/versions.props
+++ b/versions.props
@@ -8,3 +8,5 @@ org.slf4j:* = 2.0.17
 com.palantir.safe-logging:* = 3.11.0
 com.palantir.conjure:conjure = 4.54.0
 com.palantir.conjure.java:* = 8.69.0
+one.util:streamex = 0.8.4
+org.mockito:* = 5.21.0


### PR DESCRIPTION
## Before this PR
The java CM SDK did not post function schemas to the runtime, which meant function schemas could not be inferred & imported when using this SDK.

## After this PR
==COMMIT_MSG==
Add function schema inference
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

