### PR TITLE
Allow returning `Optional<T>` values from functions

### DIFF
--- a/lib/src/main/java/com/palantir/computemodules/functions/serde/Mapper.java
+++ b/lib/src/main/java/com/palantir/computemodules/functions/serde/Mapper.java
@@ -17,6 +17,7 @@ package com.palantir.computemodules.functions.serde;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public final class Mapper {
@@ -25,6 +26,7 @@ public final class Mapper {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
+            .registerModule(new Jdk8Module())
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     public static ObjectMapper get() {

--- a/lib/src/test/java/com/palantir/computemodules/functions/serde/DefaultSerializerDeserializerTest.java
+++ b/lib/src/test/java/com/palantir/computemodules/functions/serde/DefaultSerializerDeserializerTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class DefaultSerializerDeserializerTest {
@@ -50,6 +51,22 @@ class DefaultSerializerDeserializerTest {
         String serialized = new String(okResult.result().readAllBytes(), StandardCharsets.UTF_8);
         assertThat(serialized)
                 .describedAs("String should be serialized as JSON string")
+                .isEqualTo("\"Hello World\"");
+    }
+
+    @Test
+    void test_serialize_optional_string() throws IOException {
+        Optional<String> input = Optional.of("Hello World");
+
+        Result result = serializer.serialize(TEST_JOB_ID, input);
+
+        assertInstanceOf(Ok.class, result, "Optional string serialization should return Ok result");
+        Ok okResult = (Ok) result;
+        assertThat(okResult.jobId()).describedAs("Job ID should match input").isEqualTo(TEST_JOB_ID);
+
+        String serialized = new String(okResult.result().readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(serialized)
+                .describedAs("Optional string should be serialized as JSON string")
                 .isEqualTo("\"Hello World\"");
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Declaring a function with an `Optional<T>` return type is valid; however, if you try to serialize an `Optional.of(...)` value, you get an error.

## After this PR
Register the `Jdk8Module` to allow serializing optionals

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

