### PR TITLE
Fix `checkStyleMain` and `checkStyleTest`

### DIFF
--- a/.baseline/checkstyle/checkstyle-suppressions.xml
+++ b/.baseline/checkstyle/checkstyle-suppressions.xml
@@ -26,4 +26,11 @@
 
     <!-- Generated code should not be subjected to checkstyle. -->
     <suppress files="[/\\].*[/\\]generated.*[/\\]" checks="." />
+
+    <!-- These classes intentionally integrate with Logback directly
+         (programmatic config + custom Layout) which SLF4J cannot express. -->
+    <suppress files="logging[/\\]LoggingConfiguration\.java" id="BanLoggingImplementations" />
+    <suppress files="logging[/\\]SlsLayout\.java" id="BanLoggingImplementations" />
+    <suppress files="logging[/\\]SlsLayoutTest\.java" id="BanLoggingImplementations" />
+    <suppress files="ComputeModule\.java" id="BanLoggingImplementations" />
 </suppressions>

--- a/.baseline/checkstyle/checkstyle-suppressions.xml
+++ b/.baseline/checkstyle/checkstyle-suppressions.xml
@@ -27,10 +27,8 @@
     <!-- Generated code should not be subjected to checkstyle. -->
     <suppress files="[/\\].*[/\\]generated.*[/\\]" checks="." />
 
-    <!-- These classes intentionally integrate with Logback directly
-         (programmatic config + custom Layout) which SLF4J cannot express. -->
-    <suppress files="logging[/\\]LoggingConfiguration\.java" id="BanLoggingImplementations" />
-    <suppress files="logging[/\\]SlsLayout\.java" id="BanLoggingImplementations" />
-    <suppress files="logging[/\\]SlsLayoutTest\.java" id="BanLoggingImplementations" />
-    <suppress files="ComputeModule\.java" id="BanLoggingImplementations" />
+    <!-- Logging package and ComputeModule must import logback classes directly for layout configuration -->
+    <suppress files="[/\\]logging[/\\].*\.java$" id="BanLoggingImplementations" />
+    <suppress files="[/\\]ComputeModule\.java$" id="BanLoggingImplementations" />
+
 </suppressions>


### PR DESCRIPTION
Builds are currently failing on develop due to the `BanLoggingImplementations` checkstyle rule. I'm suppressing this rule, as the logging implementations are intentional.

These suppressions actually used to be in the repo originally, but were incorrectly removed by https://github.com/palantir/java-compute-module/pull/207, which auto-merged because the repo wasn't blocking PRs with failing checks from merging.

